### PR TITLE
Dataloading workaround

### DIFF
--- a/config/exp/maestro22k_8s.yaml
+++ b/config/exp/maestro22k_8s.yaml
@@ -37,7 +37,7 @@ num_accumulation_rounds: 1 #gradient accumulation, truncated backprop
 use_fp16: False #',          help='Enable mixed-precision training', metavar='BOOL',            type=bool, default=False, show_default=True)
 ls: 1 #',            help='Loss scaling', metavar='FLOAT',                              type=click.FloatRange(min=0, min_open=True), default=1, show_default=True)
 bench: True #',         help='Enable cuDNN benchmarking', metavar='BOOL',                  type=bool, default=True, show_default=True)
-num_workers: 4  #',       help='DataLoader worker processes', metavar='INT',                 type=click.IntRange(min=1), default=1, show_default=True)
+num_workers: 0  #',       help='DataLoader worker processes', metavar='INT',                 type=click.IntRange(min=1), default=1, show_default=True)
 
 # I/O-related. moved to logging
 seed: 42 #',          help='Random seed  [default: random]', metavar='INT',              type=int)

--- a/config/extract_bounds_inpainting_center_conffusion.json
+++ b/config/extract_bounds_inpainting_center_conffusion.json
@@ -49,9 +49,9 @@
                 },
                 "val_args":{ // arguments to initialize valid_dataloader, will overwrite the parameters in train_dataloader
                     "batch_size": 1, // batch size in each gpu
-                    "num_workers": 4,
+                    "num_workers": 1,
                     "shuffle": false,
-                    "pin_memory": true,
+                    "pin_memory": false,
                     "drop_last": false
                 }
             }
@@ -86,7 +86,7 @@
                 "args":{
                     "batch_size": 1,
                     "num_workers": 1,
-                    "pin_memory": true,
+                    "pin_memory": false,
                     "shuffle": false,
                     "drop_last": false
                 }
@@ -121,7 +121,7 @@
                 "args":{
                     "batch_size": 1,
                     "num_workers": 1,
-                    "pin_memory": true,
+                    "pin_memory": false,
                     "shuffle": false,
                     "drop_last": false
                 }
@@ -156,7 +156,7 @@
                 "args":{
                     "batch_size": 1,
                     "num_workers": 1,
-                    "pin_memory": true,
+                    "pin_memory": false,
                     "shuffle": false,
                     "drop_last": false
                 }

--- a/config/extract_bounds_inpainting_center_conffusion.json
+++ b/config/extract_bounds_inpainting_center_conffusion.json
@@ -42,16 +42,16 @@
                 "validation_split": 2, // percent or number 
                 "args":{ // arguments to initialize train_dataloader
                     "batch_size": 3, // batch size in each gpu
-                    "num_workers": 4,
+                    "num_workers": 0,
                     "shuffle": true,
                     "pin_memory": true,
                     "drop_last": true
                 },
                 "val_args":{ // arguments to initialize valid_dataloader, will overwrite the parameters in train_dataloader
                     "batch_size": 1, // batch size in each gpu
-                    "num_workers": 1,
+                    "num_workers": 0,
                     "shuffle": false,
-                    "pin_memory": false,
+                    "pin_memory": true,
                     "drop_last": false
                 }
             }
@@ -85,8 +85,8 @@
                 "default_file_name": "data.dataset_audio",
                 "args":{
                     "batch_size": 1,
-                    "num_workers": 1,
-                    "pin_memory": false,
+                    "num_workers": 0,
+                    "pin_memory": true,
                     "shuffle": false,
                     "drop_last": false
                 }
@@ -120,8 +120,8 @@
                 "default_file_name": "data.dataset_audio",
                 "args":{
                     "batch_size": 1,
-                    "num_workers": 1,
-                    "pin_memory": false,
+                    "num_workers": 0,
+                    "pin_memory": true,
                     "shuffle": false,
                     "drop_last": false
                 }
@@ -155,8 +155,8 @@
                 "default_file_name": "data.dataset_audio",
                 "args":{
                     "batch_size": 1,
-                    "num_workers": 1,
-                    "pin_memory": false,
+                    "num_workers": 0,
+                    "pin_memory": true,
                     "shuffle": false,
                     "drop_last": false
                 }

--- a/data/dataset_audio.py
+++ b/data/dataset_audio.py
@@ -24,6 +24,10 @@ def make_dataset(dir):
                 if is_audio_file(fname):
                     path = os.path.join(root, fname)
                     audios.append(path)
+    dir_bounds = dir.replace('ground_truth', 'sampled_bounds')
+    sampled_bounds = list(os.walk(dir_bounds))[1][-1]
+    sampled_bounds = [sampled.rsplit('_long_sampled_upper')[0] for sampled in sampled_bounds]
+    audios = [s for s in audios if not any(xs in s for xs in sampled_bounds)]
 
     return audios
 


### PR DESCRIPTION
Specific workaround for runtime error :
RuntimeError: RuntimeErrorPin memory thread exited unexpectedly:
Pin memory thread exited unexpectedly

Specifically, ignore pin_memory which is not working well on batch end. And look in the upper_bound directory to remove audios which boundaries were already extracted for.